### PR TITLE
AsyncTCPConnection can now use a preinitialized socket

### DIFF
--- a/source/libasync/posix2.d
+++ b/source/libasync/posix2.d
@@ -10,8 +10,10 @@ mixin template RunKill()
 		m_status = StatusInfo.init;
 		import libasync.internals.socket_compat : socket, SOCK_STREAM;
 		import core.sys.posix.unistd : close;
-		
-		fd_t fd = socket(cast(int)ctxt.peer.family, SOCK_STREAM, 0);
+		fd_t fd = ctxt.preInitializedSocket;
+
+		if (fd == fd_t.init)
+			fd = socket(cast(int)ctxt.peer.family, SOCK_STREAM, 0);
 		
 		if (catchError!("run AsyncTCPConnection")(fd)) 
 			return 0;

--- a/source/libasync/tcp.d
+++ b/source/libasync/tcp.d
@@ -17,13 +17,17 @@ private:
 
 nothrow:
 	fd_t m_socket;
+	fd_t m_preInitializedSocket;
 	bool m_noDelay;
 	bool m_inbound;
 	debug bool m_dataRemaining;
 public:
-	this(EventLoop evl)
+	this(EventLoop evl, fd_t preInitializedSocket = fd_t.init)
 	in { assert(evl !is null); }
-	body { m_evLoop = evl; }
+	body {
+		m_evLoop = evl;
+		m_preInitializedSocket = preInitializedSocket;
+	}
 
 	mixin DefStatus;
 
@@ -175,6 +179,9 @@ package:
 		m_socket = sock;
 	}
 
+	@property fd_t preInitializedSocket() const {
+		return m_preInitializedSocket;
+	}
 }
 
 /// Accepts connections on a single IP:PORT tuple by sending a new inbound AsyncTCPConnection 


### PR DESCRIPTION
When you want to bind the socket to a specific local address or you simply already have the socket handed by a third party library, it would be useful that the AsyncTCPConnection class can take such a socket instance as constructor parameter.


