### PR TITLE
Using ranges as recv and send args

### DIFF
--- a/source/libasync/tcp.d
+++ b/source/libasync/tcp.d
@@ -3,6 +3,7 @@ import std.traits : isPointer;
 import libasync.types;
 import libasync.events;
 import std.typecons : Tuple;
+import std.range : isInputRange, isOutputRange;
 
 /// Wraps a TCP stream between 2 network adapters, using a custom handler to
 /// signal related events. Many of these objects can be active concurrently 
@@ -127,7 +128,7 @@ public:
 
 	/// Receive data from the underlying stream. To be used when TCPEvent.READ is received by the
 	/// callback handler. IMPORTANT: This must be called until is returns a lower value than the buffer!
-	uint recv(ref ubyte[] ub)
+	uint recv(R)(R ub) if (isOutputRange!(R, ubyte))
 	in { assert(isConnected, "No socket to operate on"); }
 	body {
 		uint cnt = m_evLoop.recv(m_socket, ub);
@@ -139,7 +140,7 @@ public:
 	}
 
 	/// Send data through the underlying stream by moving it into the OS buffer.
-	uint send(in ubyte[] ub)
+	uint send(R)(R ub) if (isInputRange!R)
 	in { assert(isConnected, "No socket to operate on"); }
 	body {
 		version(Posix)


### PR DESCRIPTION
I've replaced the byte arrays with input range for `recv` and output range for `send` so custom ranges (eg. circular buffer) can be used with these methods.