### PR TITLE
Fixed error creating sockets on versions of linux that do not support SO...

### DIFF
--- a/source/libasync/posix.d
+++ b/source/libasync/posix.d
@@ -581,9 +581,18 @@ package:
 					err = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, len);
 					if (!errorHandler())
 						return false;
+
 					// BSD systems have SO_REUSEPORT
 					import libasync.internals.socket_compat : SO_REUSEPORT;
 					err = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &val, len);
+					
+					// Not all linux kernels support SO_REUSEPORT
+					version(linux) {
+						// ignore invalid and not supported errors on linux
+						if (errno == EINVAL || errno == ENOPROTOOPT) {
+							return true;
+						}						
+					} 
 
 					return errorHandler();
 				}

--- a/source/libasync/posix2.d
+++ b/source/libasync/posix2.d
@@ -8,12 +8,12 @@ mixin template RunKill()
 	in { assert(ctxt.socket == fd_t.init, "TCP Connection is active. Use another instance."); }
 	body {
 		m_status = StatusInfo.init;
-		import libasync.internals.socket_compat : socket, SOCK_STREAM;
+		import libasync.internals.socket_compat : socket, SOCK_STREAM, IPPROTO_TCP;
 		import core.sys.posix.unistd : close;
 		fd_t fd = ctxt.preInitializedSocket;
 
 		if (fd == fd_t.init)
-			fd = socket(cast(int)ctxt.peer.family, SOCK_STREAM, 0);
+			fd = socket(cast(int)ctxt.peer.family, SOCK_STREAM, IPPROTO_TCP);
 		
 		if (catchError!("run AsyncTCPConnection")(fd)) 
 			return 0;


### PR DESCRIPTION
..._REUSEPORT.

Ignores EINVAL and ENOPROTOOPT when setting SO_REUSEPORT on linux builds.