### PR TITLE
Update to delay the creation of async threads

### DIFF
--- a/source/libasync/events.d
+++ b/source/libasync/events.d
@@ -44,6 +44,7 @@ final class EventLoop
 
 package:
 	EventLoopImpl m_evLoop;
+	bool m_asyncThreadsStarted = false;
 
 nothrow:
 public:
@@ -227,6 +228,13 @@ package:
 	*/
 	public bool loop(Duration max_timeout = 100.msecs)
 	{
+		if(!m_asyncThreadsStarted) {
+			if(!spawnAsyncThreads()) {
+				return false;
+			}
+			m_asyncThreadsStarted = true;
+		}
+
 		if (!m_evLoop.loop(max_timeout) && m_evLoop.status.code == Status.EVLOOP_FAILURE)
 			return false;
 


### PR DESCRIPTION
Calling ```spawnAsyncThreads()``` will cause the async threads to be created, if they have not been created.  EventLoop.loop will also try to call ```spawnAsyncThreads()``` on the first call.
This allows existing code to continue to work as expected without requiring an update to including a call to ```spawnAsyncThreads()```.

Fixes #21 
 