### PR TITLE
sockAddrLen() returns uint 

### DIFF
--- a/source/libasync/posix.d
+++ b/source/libasync/posix.d
@@ -2707,7 +2707,7 @@ public struct NetworkAddress {
 	
 	/** Size of the sockaddr struct that is returned by sockAddr().
 		*/
-	@property int sockAddrLen()
+	@property uint sockAddrLen()
 	const pure nothrow {
 		switch (this.family) {
 			default: assert(false, "sockAddrLen() called for invalid address family.");

--- a/source/libasync/windows.d
+++ b/source/libasync/windows.d
@@ -1890,7 +1890,7 @@ public struct NetworkAddress {
 	
 	/** Size of the sockaddr struct that is returned by sockAddr().
 		*/
-	@property int sockAddrLen()
+	@property uint sockAddrLen()
 	const pure nothrow {
 		switch (this.family) {
 			default: assert(false, "sockAddrLen() called for invalid address family.");


### PR DESCRIPTION
`sockAddrLen()` should never return negative values, thus instead of `int` return `uint`