### PR TITLE
Make file descriptors public read

### DIFF
--- a/source/libasync/notifier.d
+++ b/source/libasync/notifier.d
@@ -47,13 +47,12 @@ public:
 		return m_evLoop.notify(m_evId, this);
 	}
 
-package:
-
-	version(Posix) mixin EvInfoMixins;
-
-	@property id() const {
+	@property fd_t id() const {
 		return m_evId;
 	}
+
+package:
+	version(Posix) mixin EvInfoMixins;
 
 	void handler() {
 		try m_evh();

--- a/source/libasync/signal.d
+++ b/source/libasync/signal.d
@@ -91,15 +91,13 @@ public:
 	synchronized @property Thread owner() const {
 		return cast(Thread) m_owner;
 	}
-package:
-	
 
-
-	version(Posix) mixin EvInfoMixinsShared;
-
-	@property id() const {
+	@property fd_t id() const {
 		return m_evId;
 	}
+
+package:
+	version(Posix) mixin EvInfoMixinsShared;
 
 	void handler() {
 		try m_sgh();

--- a/source/libasync/tcp.d
+++ b/source/libasync/tcp.d
@@ -159,6 +159,10 @@ public:
 		return ret;
 	}
 
+	@property fd_t socket() const {
+		return m_socket;
+	}
+
 package:
 	mixin TCPConnectionMixins;
 
@@ -169,10 +173,6 @@ package:
 	@property bool noDelay() const
 	{
 		return m_noDelay;
-	}
-
-	@property fd_t socket() const {
-		return m_socket;
 	}
 
 	@property void socket(fd_t sock) {

--- a/source/libasync/timer.d
+++ b/source/libasync/timer.d
@@ -110,14 +110,13 @@ public:
 		return m_evLoop.kill(this);
 	}
 
-package:
-
-	version(Posix) mixin EvInfoMixins;
-	
 	@property fd_t id() {
 		return m_timerId;
 	}
 	
+package:
+	version(Posix) mixin EvInfoMixins;
+
 	@property void id(fd_t fd) {
 		m_timerId = fd;
 	}

--- a/source/libasync/udp.d
+++ b/source/libasync/udp.d
@@ -104,12 +104,12 @@ public:
 		return m_evLoop.kill(this);
 	}
 
-package:
-	version(Posix) mixin EvInfoMixins;
-
 	@property fd_t socket() const {
 		return m_socket;
 	}
+
+package:
+	version(Posix) mixin EvInfoMixins;
 
 	@property void socket(fd_t val) {
 		m_socket = val;

--- a/source/libasync/watcher.d
+++ b/source/libasync/watcher.d
@@ -133,13 +133,13 @@ public:
 		return m_evLoop.kill(this);
 	}
 	
-package:
-	version(Posix) mixin EvInfoMixins;
-	
 	@property fd_t fd() const {
 		return m_fd;
 	}
 	
+package:
+	version(Posix) mixin EvInfoMixins;
+
 	@property void fd(fd_t val) {
 		m_fd = val;
 	}


### PR DESCRIPTION
Move the property read method of the file descriptors to the public section.
This is especially necessary for reading the file descriptors of the accepted connections.