### PR TITLE
Add TCPOption.REUSEPORT to windows version

### DIFF
--- a/source/libasync/windows.d
+++ b/source/libasync/windows.d
@@ -531,6 +531,7 @@ package:
 						err = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, len);
 						return errorHandler();
 					}
+				case TCPOption.REUSEPORT:
 				case TCPOption.REUSEADDR: // true/false
 					static if (!is(T == bool))
 						assert(false, "REUSEADDR value type must be bool, not " ~ T.stringof);


### PR DESCRIPTION
I see no real harm using this simple fix, quote from http://stackoverflow.com/questions/17212789/multiple-processes-listening-on-the-same-port
```
Windows only knows the SO_REUSEADDR option, there is no SO_REUSEPORT. Setting SO_REUSEADDR on a socket in Windows behaves like setting SO_REUSEPORT and SO_REUSEADDR on a socket in BSD, with one exception: A socket with SO_REUSEADDR can always bind to exactly the same source address and port as an already bound socket, even if the other socket did not have this option set when it was bound. This behavior is somewhat dangerous because it allows an* application "to steal" the connected port of another application. Needless to say, this can have major security implications.
```