### PR TITLE
add empty ddoc stubs for doc generation hooks to public methods

### DIFF
--- a/source/libasync/bufferedtcp.d
+++ b/source/libasync/bufferedtcp.d
@@ -1,3 +1,4 @@
+///
 module libasync.bufferedtcp;
 
 import std.algorithm : copy;
@@ -10,9 +11,12 @@ import libasync.events;
 import libasync.tcp    : AsyncTCPConnection, TCPEvent, TCPEventHandler;
 import libasync.types  : StatusInfo;
 
+///
 final class BufferedTCPConnection(size_t size = 4092)
 {
+    ///
     alias OnEvent = void delegate(BufferedTCPConnection!size conn);
+    ///
     alias OnRead  =
         void delegate(BufferedTCPConnection!size conn, in ubyte[] msg);
 
@@ -31,6 +35,7 @@ final class BufferedTCPConnection(size_t size = 4092)
         ubyte[] workBuffer = new ubyte[size];
     }
 
+    ///
     this(
         EventLoop evl,
         fd_t preInitializedSocket = fd_t.init,
@@ -50,6 +55,7 @@ final class BufferedTCPConnection(size_t size = 4092)
         this.onErrorCb   = onErrorCb;
     }
 
+    ///
     this(
         AsyncTCPConnection conn,
         in OnEvent onConnectCb = null,
@@ -68,6 +74,7 @@ final class BufferedTCPConnection(size_t size = 4092)
         this.onErrorCb   = onErrorCb;
     }
 
+    ///
     @property bool hasError() const
     {
         return asyncConn.hasError;
@@ -92,6 +99,7 @@ final class BufferedTCPConnection(size_t size = 4092)
         return asyncConn.error;
     }
 
+    ///
     @property bool isConnected() const nothrow
     {
         return asyncConn.isConnected;
@@ -216,6 +224,7 @@ final class BufferedTCPConnection(size_t size = 4092)
         return ret;
     }
 
+    ///
     void read(in size_t len, in OnRead onReadCb)
     {
         onReadCbs ~= OnReadInfo(len, onReadCb);
@@ -242,6 +251,7 @@ final class BufferedTCPConnection(size_t size = 4092)
                 break;
     }
 
+    ///
     void write(R)(in R msg, in size_t len, in OnEvent cb = null)
     if (isInputRange!R)
     {
@@ -282,6 +292,7 @@ final class BufferedTCPConnection(size_t size = 4092)
             onErrorCb(this);
     }
 
+    ///
     void close()
     {
         kill();
@@ -294,6 +305,7 @@ final class BufferedTCPConnection(size_t size = 4092)
             onCloseCb(this);
     }
 
+    ///
     void handle(TCPEvent ev)
     {
         final switch (ev)

--- a/source/libasync/dns.d
+++ b/source/libasync/dns.d
@@ -1,4 +1,5 @@
-﻿module libasync.dns;
+﻿///
+module libasync.dns;
 
 import libasync.types;
 import libasync.events;
@@ -8,8 +9,11 @@ import core.sync.condition;
 import core.atomic;
 import libasync.threads;
 
+///
 enum DNSCmd {
+	///
 	RESOLVEHOST,
+	///
 	RESOLVEIP
 }
 
@@ -27,6 +31,7 @@ private:
 	Thread m_owner;
 
 public:
+	///
 	this(EventLoop evl) {
 		m_evLoop = cast(shared) evl;
 		try m_cmdInfo.ready = new shared AsyncSignal(cast(EventLoop)m_evLoop); catch { assert(false, "Failed to start DNS Signaling"); }
@@ -35,11 +40,13 @@ public:
 		try m_cmdInfo.mtx = cast(shared) new Mutex; catch {}
 	}
 
+	///
 	synchronized @property StatusInfo status() const
 	{
 		return cast(StatusInfo) m_status;
 	}
 
+	///
 	@property string error() const
 	{
 		return status.text;

--- a/source/libasync/event.d
+++ b/source/libasync/event.d
@@ -1,4 +1,5 @@
-﻿module libasync.event;
+﻿///
+module libasync.event;
 
 import core.thread;
 import libasync.types;
@@ -17,6 +18,7 @@ private:
 	bool m_stateful;
 
 public:
+	///
 	this(EventLoop evl, fd_t ev_id, bool stateful = false)
 	in {
 		assert(evl !is null && ev_id > 0);
@@ -29,6 +31,7 @@ public:
 		m_stateful = stateful;
 	}
 
+	///
 	@property bool hasError() const
 	{
 		return (cast(EventLoop)m_evLoop).status.code != Status.OK;
@@ -62,6 +65,7 @@ public:
 		return cast(Thread) m_owner;
 	}
 
+	///
 	@property fd_t id() const {
 		return m_evId;
 	}
@@ -89,10 +93,16 @@ package struct EventHandler {
 	}
 }
 
+///
 enum EventCode : char {
+	///
 	ERROR = 0,
+	///
 	READ,
+	///
 	WRITE,
+	///
 	CONNECT,
+	///
 	CLOSE
 }

--- a/source/libasync/events.d
+++ b/source/libasync/events.d
@@ -1,3 +1,4 @@
+///
 module libasync.events;
 
 import std.stdio;
@@ -30,6 +31,7 @@ version(Posix) {
 	public import libasync.posix;
 }
 
+///
 EventLoop getThreadEventLoop() nothrow {
 	static EventLoop evLoop;
 	if (!evLoop)  {
@@ -50,6 +52,7 @@ package:
 
 nothrow:
 public:
+	///
 	this() {
 		if (m_evLoop.started || !m_evLoop.init(this))
 			assert(false, "Event loop initialization failure");
@@ -62,6 +65,7 @@ public:
 		m_evLoop.exit();
 	}
 
+	///
 	NetworkAddress resolveIP(in string ip, ushort port = 0, isIPv6 ipv6 = isIPv6.no, isTCP tcp = isTCP.yes, isForced force = isForced.yes)
 	{
 		if (!force)
@@ -72,7 +76,7 @@ public:
 		return addr;
 	}
 
-	/* Blocks until the hostname is resolved, unless it's invalid. */
+	/** Blocks until the hostname is resolved, unless it's invalid. */
 	NetworkAddress resolveHost(in string host, ushort port = 0, isIPv6 ipv6 = isIPv6.no, isTCP tcp = isTCP.yes, isForced force = isForced.yes)
 	{
 		if (!force)

--- a/source/libasync/file.d
+++ b/source/libasync/file.d
@@ -1,4 +1,5 @@
-﻿module libasync.file;
+﻿///
+module libasync.file;
 import libasync.types;
 import libasync.events;
 import core.thread : Thread, ThreadGroup;
@@ -28,6 +29,7 @@ private:
 	File* m_file;
 
 public:
+	///
 	this(EventLoop evl) {
 		m_evLoop = cast(shared) evl;
 		m_cmdInfo.ready = new shared AsyncSignal(cast(EventLoop)m_evLoop);
@@ -49,11 +51,13 @@ public:
 		return true;
 	}
 
+	///
 	synchronized @property StatusInfo status() const
 	{
 		return cast(StatusInfo) m_status;
 	}
 
+	///
 	@property string error() const
 	{
 		return status.text;

--- a/source/libasync/notifier.d
+++ b/source/libasync/notifier.d
@@ -1,4 +1,5 @@
-﻿module libasync.notifier;
+﻿///
+module libasync.notifier;
 
 import libasync.types;
 import libasync.events;
@@ -7,6 +8,7 @@ import libasync.events;
 /// callback in a new call stack originating from the event loop.
 final class AsyncNotifier
 {
+	///
 	void delegate() m_evh;
 nothrow:
 private:
@@ -15,6 +17,7 @@ private:
 	version(Posix) static if (EPOLL) shared ushort m_owner;
 
 public:
+	///
 	this(EventLoop evl)
 	in {
 		assert(evl !is null);
@@ -47,6 +50,7 @@ public:
 		return m_evLoop.notify(m_evId, this);
 	}
 
+	///
 	@property fd_t id() const {
 		return m_evId;
 	}

--- a/source/libasync/package.d
+++ b/source/libasync/package.d
@@ -1,3 +1,4 @@
-﻿module libasync;
+﻿///
+module libasync;
 
 public import libasync.events;

--- a/source/libasync/signal.d
+++ b/source/libasync/signal.d
@@ -1,3 +1,4 @@
+///
 module libasync.signal;
 import std.traits;
 
@@ -18,6 +19,7 @@ private:
 
 public:
 
+	///
 	this(EventLoop evl)
 	in {
 		assert(evl !is null);
@@ -37,6 +39,7 @@ public:
 		}
 	}
 
+	///
 	@property bool hasError() const
 	{
 		return (cast(EventLoop)m_evLoop).status.code != Status.OK;
@@ -92,6 +95,7 @@ public:
 		return cast(Thread) m_owner;
 	}
 
+	///
 	@property fd_t id() const {
 		return m_evId;
 	}

--- a/source/libasync/tcp.d
+++ b/source/libasync/tcp.d
@@ -1,3 +1,4 @@
+///
 module libasync.tcp;
 import std.traits : isPointer;
 import libasync.types;
@@ -21,6 +22,7 @@ nothrow:
 	bool m_noDelay;
 	bool m_inbound;
 public:
+	///
 	this(EventLoop evl, fd_t preInitializedSocket = fd_t.init)
 	in { assert(evl !is null); }
 	body {
@@ -113,6 +115,7 @@ public:
 		return run(handler);
 	}
 
+	///
 	bool run(TCPEventHandler del)
 	in { assert(!isConnected); }
 	body {
@@ -198,6 +201,7 @@ nothrow:
 
 public:
 
+	///
 	this(EventLoop evl, fd_t sock = fd_t.init) { m_evLoop = evl; m_socket = sock; }
 
 	mixin DefStatus;
@@ -315,30 +319,32 @@ package struct TCPAcceptHandler {
 	}
 }
 
+///
 enum TCPEvent : char {
-	ERROR = 0, // The connection will be forcefully closed, this is debugging information
-	CONNECT, // indicates write will not block, although recv may or may not have data
-	READ, // called once when new bytes are in the buffer
-	WRITE, // only called when send returned Status.ASYNC
-	CLOSE // The connection is being shutdown
+	ERROR = 0, /// The connection will be forcefully closed, this is debugging information
+	CONNECT, /// indicates write will not block, although recv may or may not have data
+	READ, /// called once when new bytes are in the buffer
+	WRITE, /// only called when send returned Status.ASYNC
+	CLOSE /// The connection is being shutdown
 }
 
+///
 enum TCPOption : char {
-	NODELAY = 0,		// Don't delay send to coalesce packets
-	REUSEADDR = 1,
-	REUSEPORT,
-	CORK,
-	LINGER,
-	BUFFER_RECV,
-	BUFFER_SEND,
-	TIMEOUT_RECV,
-	TIMEOUT_SEND,
-	TIMEOUT_HALFOPEN,
-	KEEPALIVE_ENABLE,
-	KEEPALIVE_DEFER,	// Start keeplives after this period
-	KEEPALIVE_COUNT,	// Number of keepalives before death
-	KEEPALIVE_INTERVAL,	// Interval between keepalives
-	DEFER_ACCEPT,
-	QUICK_ACK,			// Bock/reenable quick ACKs.
-	CONGESTION
+	NODELAY = 0,		/// Don't delay send to coalesce packets
+	REUSEADDR = 1, ///
+	REUSEPORT, ///
+	CORK, ///
+	LINGER, ///
+	BUFFER_RECV, ///
+	BUFFER_SEND, ///
+	TIMEOUT_RECV, ///
+	TIMEOUT_SEND, ///
+	TIMEOUT_HALFOPEN, ///
+	KEEPALIVE_ENABLE, ///
+	KEEPALIVE_DEFER,	/// Start keeplives after this period
+	KEEPALIVE_COUNT,	/// Number of keepalives before death
+	KEEPALIVE_INTERVAL,	/// Interval between keepalives
+	DEFER_ACCEPT, ///
+	QUICK_ACK,			/// Bock/reenable quick ACKs.
+	CONGESTION ///
 }

--- a/source/libasync/timer.d
+++ b/source/libasync/timer.d
@@ -1,9 +1,11 @@
-﻿module libasync.timer;
+﻿///
+module libasync.timer;
 
 import libasync.types;
 import libasync.events;
 import std.datetime;
 
+///
 final class AsyncTimer
 {
 
@@ -18,6 +20,7 @@ private:
 	bool m_rearmed = false;
 
 public:
+	///
 	this(EventLoop evl)
 	in { assert(evl !is null); }
 	body { m_evLoop = evl; }
@@ -110,6 +113,7 @@ public:
 		return m_evLoop.kill(this);
 	}
 
+	///
 	@property fd_t id() {
 		return m_timerId;
 	}

--- a/source/libasync/udp.d
+++ b/source/libasync/udp.d
@@ -1,4 +1,5 @@
-﻿module libasync.udp;
+﻿///
+module libasync.udp;
 
 import libasync.types;
 
@@ -15,6 +16,7 @@ private:
 	NetworkAddress m_local;
 
 public:
+	///
 	this(EventLoop evl, fd_t preInitializedSocket = fd_t.init)
 	in { assert(evl !is null); }
 	body {
@@ -135,8 +137,9 @@ package struct UDPHandler {
 	}
 }
 
+///
 enum UDPEvent : char {
-	ERROR = 0,
-	READ,
-	WRITE
+	ERROR = 0, ///
+	READ, ///
+	WRITE ///
 }

--- a/source/libasync/uds.d
+++ b/source/libasync/uds.d
@@ -1,3 +1,4 @@
+///
 module libasync.uds;
 
 version (Posix):
@@ -10,6 +11,7 @@ import libasync.event;
 
 import core.sys.posix.sys.socket;
 
+///
 final class AsyncUDSConnection
 {
 package:
@@ -37,6 +39,7 @@ package:
 	}
 
 public:
+	///
 	this(EventLoop evl, fd_t preInitializedSocket = fd_t.init)
 	in { assert(evl !is null); }
 	body {
@@ -56,11 +59,13 @@ public:
 		return m_inbound;
 	}
 
+	///
 	@property UnixAddress peer() const
 	{
 		return cast(UnixAddress) m_peer;
 	}
 
+	///
 	@property void peer(UnixAddress addr)
 	in {
 		assert(!isConnected, "Cannot change remote address on a connected socket");
@@ -70,6 +75,7 @@ public:
 		m_peer = addr;
 	}
 
+	///
 	bool run(void delegate(EventCode) del)
 	in { assert(!isConnected); }
 	body {
@@ -108,6 +114,7 @@ public:
 	}
 }
 
+///
 final class AsyncUDSListener
 {
 package:
@@ -148,6 +155,7 @@ package:
 	}
 
 public:
+	///
 	this(EventLoop evl, bool unlinkFirst = true)
 	in { assert(evl !is null); }
 	body {

--- a/source/libasync/watcher.d
+++ b/source/libasync/watcher.d
@@ -1,4 +1,5 @@
-﻿module libasync.watcher;
+﻿///
+module libasync.watcher;
 
 import libasync.types;
 
@@ -21,6 +22,7 @@ private:
 	fd_t m_fd;
 	debug bool m_dataRemaining;
 public:
+	///
 	this(EventLoop evl)
 	in { assert(evl !is null); }
 	body { m_evLoop = evl; }
@@ -135,6 +137,7 @@ public:
 		return m_evLoop.kill(this);
 	}
 
+	///
 	@property fd_t fd() const {
 		return m_fd;
 	}
@@ -155,10 +158,12 @@ struct DWChangeInfo {
 	/// The os-independent address of the file/folder
 	private Path m_path;
 
+	///
 	@property string path() {
 		return m_path.toNativeString();
 	}
 
+	///
 	@property void path(Path p) {
 		m_path = p;
 	}
@@ -168,13 +173,13 @@ struct DWChangeInfo {
 /// List of events that can be watched for. They must be 'Or'ed together
 /// to combined them when calling watch(). OS-triggerd events are exclusive.
 enum DWFileEvent : uint {
-	ERROR = 0,
-	MODIFIED = 0x00000002,
-	MOVED_FROM = 0x00000040,
-	MOVED_TO = 0x00000080,
-	CREATED = 0x00000100,
-	DELETED = 0x00000200,
-	ALL = MODIFIED | MOVED_FROM | MOVED_TO | CREATED | DELETED
+	ERROR = 0, ///
+	MODIFIED = 0x00000002, ///
+	MOVED_FROM = 0x00000040, ///
+	MOVED_TO = 0x00000080, ///
+	CREATED = 0x00000100, ///
+	DELETED = 0x00000200, ///
+	ALL = MODIFIED | MOVED_FROM | MOVED_TO | CREATED | DELETED ///
 }
 
 


### PR DESCRIPTION
The goal here is to just indicate that these are meant to be public. I didn't write anything, but this way the doc generators know to at least list them as available.