### PR TITLE
Fix exception specification deprecation warnings

### DIFF
--- a/source/libasync/dns.d
+++ b/source/libasync/dns.d
@@ -34,10 +34,14 @@ public:
 	///
 	this(EventLoop evl) {
 		m_evLoop = cast(shared) evl;
-		try m_cmdInfo.ready = new shared AsyncSignal(cast(EventLoop)m_evLoop); catch { assert(false, "Failed to start DNS Signaling"); }
+		try {
+			m_cmdInfo.ready = new shared AsyncSignal(cast(EventLoop)m_evLoop);
+		} catch (Throwable) {
+			assert(false, "Failed to start DNS Signaling");
+		}
 		m_cmdInfo.ready.run(cast(void delegate())&callback);
 		m_owner = cast(shared)Thread.getThis();
-		try m_cmdInfo.mtx = cast(shared) new Mutex; catch {}
+		try m_cmdInfo.mtx = cast(shared) new Mutex; catch (Exception) {}
 	}
 
 	///
@@ -57,7 +61,8 @@ public:
 		shared DNSReadyHandler handler;
 		handler.del = cast(shared) del;
 		handler.ctxt = this;
-		try synchronized(this) m_handler = handler; catch { assert(false, "Failed to set handler in AsyncDNS"); }
+		try synchronized(this) m_handler = handler;
+		catch (Throwable) assert(false, "Failed to set handler in AsyncDNS");
 		return this;
 	}
 
@@ -75,7 +80,7 @@ public:
 				m_cmdInfo.command = DNSCmd.RESOLVEHOST;
 				m_cmdInfo.ipv6 = ipv6;
 				m_cmdInfo.url = cast(shared) url;
-			} catch {}
+			} catch (Exception) {}
 		} else {
 			m_cmdInfo.command = DNSCmd.RESOLVEHOST;
 			m_cmdInfo.ipv6 = ipv6;
@@ -111,7 +116,7 @@ package:
 	shared(NetworkAddress*) addr() {
 		try synchronized(m_cmdInfo.mtx)
 			return cast(shared)&m_cmdInfo.addr;
-		catch {}
+		catch (Exception) {}
 		return null;
 	}
 
@@ -135,7 +140,7 @@ package:
 		catch (Throwable e) {
 			static if (DEBUG) {
 				import std.stdio : writeln;
-				try writeln("Failed to send command. ", e.toString()); catch {}
+				try writeln("Failed to send command. ", e.toString()); catch (Throwable) {}
 			}
 		}
 	}
@@ -187,7 +192,7 @@ private void process(shared AsyncDNS ctxt) {
 	} catch (Throwable e) {
 		auto status = StatusInfo.init;
 		status.code = Status.ERROR;
-		try status.text = e.toString(); catch {}
+		try status.text = e.toString(); catch (Throwable) {}
 		ctxt.status = status;
 	}
 
@@ -195,7 +200,7 @@ private void process(shared AsyncDNS ctxt) {
 	catch (Throwable e) {
 		auto status = StatusInfo.init;
 		status.code = Status.ERROR;
-		try status.text = e.toString(); catch {}
+		try status.text = e.toString(); catch (Throwable) {}
 		ctxt.status = status;
 	}
 }

--- a/source/libasync/file.d
+++ b/source/libasync/file.d
@@ -38,7 +38,7 @@ public:
 		m_cmdInfo.ready.run(cast(void delegate())&handler);
 		m_owner = cast(shared)Thread.getThis();
 		m_file = cast(shared)new File;
-		try m_cmdInfo.mtx = cast(shared) new Mutex; catch {}
+		try m_cmdInfo.mtx = cast(shared) new Mutex; catch (Exception) {}
 	}
 
 	/// Cleans up the underlying resources. todo: make this dispose?
@@ -69,7 +69,7 @@ public:
 	shared(ubyte[]) buffer() {
 		try synchronized(m_cmdInfo.mtx)
 			return m_cmdInfo.buffer;
-		catch {}
+		catch (Exception) {}
 		return null;
 	}
 
@@ -83,7 +83,7 @@ public:
 		shared FileReadyHandler handler;
 		handler.del = del;
 		handler.ctxt = this;
-		try synchronized(this) m_handler = handler; catch {}
+		try synchronized(this) m_handler = handler; catch (Exception) {}
 		return this;
 	}
 
@@ -101,7 +101,7 @@ public:
 	}
 	body {
 		if (buffer.length == 0) {
-			try m_handler(); catch { }
+			try m_handler(); catch (Exception) { }
 			return true;
 		}
 		try {
@@ -150,16 +150,16 @@ public:
 		} catch (Exception e) {
 			auto status = StatusInfo.init;
 			status.code = Status.ERROR;
-			try status.text = "Error in read, " ~ e.toString(); catch {}
+			try status.text = "Error in read, " ~ e.toString(); catch (Exception) {}
 			m_status = cast(shared) status;
-			try m_handler(); catch { }
+			try m_handler(); catch (Exception) { }
 			return false;
 		}
 		try synchronized(m_cmdInfo.mtx) {
 			m_cmdInfo.buffer = buffer;
 			m_cmdInfo.command = FileCmd.READ;
 			filePath = Path(file_path);
-		} catch {}
+		} catch (Exception) {}
 		offset = off;
 
 		return doOffThread({ process(this); });
@@ -174,7 +174,7 @@ public:
 	}
 	body {
 		if (buffer.length == 0) {
-			try m_handler(); catch { return false; }
+			try m_handler(); catch (Exception) { return false; }
 			return true;
 		}
 		try {
@@ -223,7 +223,7 @@ public:
 		} catch (Exception e) {
 			auto status = StatusInfo.init;
 			status.code = Status.ERROR;
-			try status.text = "Error in write, " ~ e.toString(); catch {}
+			try status.text = "Error in write, " ~ e.toString(); catch (Exception) {}
 			m_status = cast(shared) status;
 			return false;
 		}
@@ -231,7 +231,7 @@ public:
 			m_cmdInfo.buffer = cast(shared(ubyte[])) buffer;
 			m_cmdInfo.command = FileCmd.WRITE;
 			filePath = Path(file_path);
-		} catch {}
+		} catch (Exception) {}
 		offset = off;
 
 		return doOffThread({ process(this); });
@@ -245,7 +245,7 @@ public:
 	}
 	body {
 		if (buffer.length == 0) {
-			try m_handler(); catch { return false; }
+			try m_handler(); catch (Exception) { return false; }
 			return true;
 		}
 		try {
@@ -290,7 +290,7 @@ public:
 		} catch (Exception e) {
 			auto status = StatusInfo.init;
 			status.code = Status.ERROR;
-			try status.text = "Error in append, " ~ e.toString(); catch {}
+			try status.text = "Error in append, " ~ e.toString(); catch (Exception) {}
 			m_status = cast(shared) status;
 			return false;
 		}
@@ -298,7 +298,7 @@ public:
 			m_cmdInfo.buffer = cast(shared(ubyte[])) buffer;
 			m_cmdInfo.command = FileCmd.APPEND;
 			filePath = Path(file_path);
-		} catch {}
+		} catch (Exception) {}
 
 		return doOffThread({ process(this); });
 	}
@@ -419,7 +419,7 @@ private void process(shared AsyncFile ctxt) {
 	} catch (Throwable e) {
 		auto status = StatusInfo.init;
 		status.code = Status.ERROR;
-		try status.text = "Error in " ~  cmd.to!string ~ ", " ~ e.toString(); catch {}
+		try status.text = "Error in " ~  cmd.to!string ~ ", " ~ e.toString(); catch (Exception) {}
 		ctxt.status = status;
 	}
 
@@ -428,7 +428,7 @@ private void process(shared AsyncFile ctxt) {
 		trace("AsyncFile Thread Error: ", e.toString());
 		auto status = StatusInfo.init;
 		status.code = Status.ERROR;
-		try status.text = e.toString(); catch {}
+		try status.text = e.toString(); catch (Exception) {}
 		ctxt.status = status;
 	}
 }

--- a/source/libasync/internals/path.d
+++ b/source/libasync/internals/path.d
@@ -214,7 +214,7 @@ struct Path {
 		hash_t ret;
 		auto strhash = &typeid(string).getHash;
 		try foreach (n; nodes) ret ^= strhash(&n.m_name);
-		catch assert(false);
+		catch (Throwable) assert(false);
 		if (m_absolute) ret ^= 0xfe3c1738;
 		if (m_endsWithSlash) ret ^= 0x6aa4352d;
 		return ret;

--- a/source/libasync/notifier.d
+++ b/source/libasync/notifier.d
@@ -60,7 +60,7 @@ package:
 
 	void handler() {
 		try m_evh();
-		catch {}
+		catch (Exception) {}
 		return;
 	}
 }

--- a/source/libasync/signal.d
+++ b/source/libasync/signal.d
@@ -105,7 +105,7 @@ package:
 
 	void handler() {
 		try m_sgh();
-		catch {}
+		catch (Throwable) {}
 		return;
 	}
 }

--- a/source/libasync/test.d
+++ b/source/libasync/test.d
@@ -65,7 +65,7 @@ void testDNS() {
 }
 
 void testDirectoryWatcher() {
-	import std.file : mkdir, write, rmdir, exists;
+	import std.file : mkdir, rmdir, exists;
 	if (exists("./hey/tmp.tmp"))
 		remove("./hey/tmp.tmp");
 	if (exists("./hey"))
@@ -90,7 +90,7 @@ void testDirectoryWatcher() {
 		mkdir("./hey");
 		assert(g_watcher.watchDir("./hey/"));
 		tm.duration(1.seconds).run({
-			import std.file : write;
+			static import std.file;
 			writeln("Writing to ./hey/tmp.tmp for the first time");
 			std.file.write("./hey/tmp.tmp", "some string");
 			tm.duration(100.msecs).run({

--- a/source/libasync/watcher.d
+++ b/source/libasync/watcher.d
@@ -70,7 +70,7 @@ public:
 			bool addWatch() {
 				WatchInfo info;
 				info.events = ev;
-				try info.path = Path(path); catch {}
+				try info.path = Path(path); catch (Exception) {}
 				info.recursive = recursive;
 
 				//writeln("Watch: ", info.path.toNativeString());
@@ -79,7 +79,7 @@ public:
 				if (wd == 0 && m_evLoop.status.code != Status.OK)
 					return false;
 				info.wd = wd;
-				try m_directories.insert(info); catch {}
+				try m_directories.insert(info); catch (Exception) {}
 				return true;
 			}
 
@@ -126,7 +126,7 @@ public:
 					}
 				}
 			}
-		} catch {}
+		} catch (Exception) {}
 		return true;
 	}
 


### PR DESCRIPTION
This pull request fixes deprecation warnings with dmd 2.072.0 beta:

* catch statement without an exception specification is deprecated; use catch(Throwable) for old behavior
* module std.file is not accessible here, perhaps add 'static import std.file;'