### PR TITLE
Update the dependency on memutils to 0.4.8

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,7 +10,7 @@
     "libs-windows": ["ws2_32", "advapi32", "user32"],
     "libs-linux": ["rt"],
     "dependencies": {
-            "memutils": { "version": "~>0.4.5" }
+            "memutils": { "version": "~>0.4.8" }
     },
     "configurations": [
             {


### PR DESCRIPTION
Since libasync doesn't build with the version of memutils under 0.4.8 because of a dmd 2.072.0 regression (etcimon/memutils#11) , I would suggest to require at least memutils 0.4.8 if possible. Also it would be great to make a new libasync release if this change is ok.

Thanks.