### PR TITLE
Remove m32mscoff configuration

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -16,11 +16,6 @@
             {
                     "name": "regular",
                     "sourceFiles-windows-x86": ["ws2_32_ex.lib"]
-            },
-            {
-                    "name": "32mscoff",
-                    "dflags-windows-x86": ["-m32mscoff"],
-                    "subConfigurations": { "memutils": "32mscoff" }
             }
     ],
     "versions": ["EnableDebugger"]


### PR DESCRIPTION
DUB supports `--arch x86_mscoff` since version 1.2.0, so the manual workaround can be removed. Not sure if this should still wait a bit or not regarding backwards compatibility.