### PR TITLE
Improve AppVeyor CI setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,22 +2,28 @@ platform: x64
 environment:
  matrix:
   - DC: dmd
-    DVersion: 2.071.0
+    DVersion: nightly
     arch: x64
   - DC: dmd
-    DVersion: 2.071.0
+    DVersion: nightly
     arch: x86
   - DC: dmd
-    DVersion: 2.070.0
+    DVersion: beta
     arch: x64
   - DC: dmd
-    DVersion: 2.070.0
+    DVersion: beta
     arch: x86
   - DC: dmd
-    DVersion: 2.069.2
+    DVersion: stable
     arch: x64
   - DC: dmd
-    DVersion: 2.069.2
+    DVersion: stable
+    arch: x86
+  - DC: dmd
+    DVersion: 2.067.2
+    arch: x64
+  - DC: dmd
+    DVersion: 2.067.2
     arch: x86
   - DC: dmd
     DVersion: 2.068.2
@@ -26,20 +32,20 @@ environment:
     DVersion: 2.068.2
     arch: x86
   - DC: ldc
-    DVersion: 1.0.0
+    DVersion: beta
+    arch: x86
+  - DC: ldc
+    DVersion: beta
     arch: x64
   - DC: ldc
-    DVersion: 0.17.1
+    DVersion: stable
+    arch: x86
+  - DC: ldc
+    DVersion: stable
     arch: x64
   - DC: ldc
-    DVersion: 0.17.0
+    DVersion: 0.17.3
     arch: x64
-
-matrix:
-  allow_failures:
-    # See https://github.com/dlang/dub/issues/618
-    # Should be removed once dub 0.9.26 is available
-    - DC: ldc
 
 skip_tags: false
 branches:
@@ -47,19 +53,49 @@ branches:
     - master
 
 install:
+  - ps: function ResolveLatestDMD
+        {
+            $version = $env:DVersion;
+            if($version -eq "stable") {
+                $latest = (Invoke-WebRequest "http://downloads.dlang.org/releases/LATEST").toString();
+                $url = "http://downloads.dlang.org/releases/2.x/$($latest)/dmd.$($latest).windows.7z";
+            }elseif($version -eq "beta") {
+                $latest = (Invoke-WebRequest "http://downloads.dlang.org/pre-releases/LATEST").toString();
+                $latestVersion = $latest.split("-")[0].split("~")[0];
+                $url = "http://downloads.dlang.org/pre-releases/2.x/$($latestVersion)/dmd.$($latest).windows.7z";
+            }elseif($version -eq "nightly") {
+                $url = "http://nightlies.dlang.org/dmd-master-2017-05-20/dmd.master.windows.7z"
+            }else {
+                $url = "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z";
+            }
+            $env:PATH += ";C:\dmd2\windows\bin;";
+            return $url;
+        }
+  - ps: function ResolveLatestLDC
+        {
+            $version = $env:DVersion;
+            if($version -eq "stable") {
+                $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST").toString().replace("`n","").replace("`r","");
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-win64-msvc.zip";
+            }elseif($version -eq "beta") {
+                $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST_BETA").toString().replace("`n","").replace("`r","");
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-win64-msvc.zip";
+            } else {
+                $latest = $version;
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip";
+            }
+            $env:PATH += ";C:\ldc2-$($latest)-win64-msvc\bin";
+            $env:DC = "ldc2";
+            return $url;
+        }
   - ps: function SetUpDCompiler
         {
+            $env:toolchain = "msvc";
             if($env:DC -eq "dmd"){
-              if($env:arch -eq "x86"){
-                $env:DConf = "m32";
-              }
-              elseif($env:arch -eq "x64"){
-                $env:DConf = "m64";
-              }
               echo "downloading ...";
-              $env:toolchain = "msvc";
-              $version = $env:DVersion;
-              Invoke-WebRequest "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z" -OutFile "c:\dmd.7z";
+              $url = ResolveLatestDMD;
+              echo $url;
+              Invoke-WebRequest $url -OutFile "c:\dmd.7z";
               echo "finished.";
               pushd c:\\;
               7z x dmd.7z > $null;
@@ -67,15 +103,9 @@ install:
             }
             elseif($env:DC -eq "ldc"){
               echo "downloading ...";
-              if($env:arch -eq "x86"){
-                $env:DConf = "m32";
-              }
-              elseif($env:arch -eq "x64"){
-                $env:DConf = "m64";
-              }
-              $env:toolchain = "msvc";
-              $version = $env:DVersion;
-              Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip" -OutFile "c:\ldc.zip";
+              $url = ResolveLatestLDC;
+              echo $url;
+              Invoke-WebRequest $url -OutFile "c:\ldc.zip";
               echo "finished.";
               pushd c:\\;
               7z x ldc.zip > $null;
@@ -83,33 +113,19 @@ install:
             }
         }
   - ps: SetUpDCompiler
-  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-0.9.25-windows-x86.zip -OutFile dub.zip
-  - 7z x dub.zip -odub > nul
-  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
-  - dub --version
 
-before_build:
+build_script:
   - ps: if($env:arch -eq "x86"){
             $env:compilersetupargs = "x86";
             $env:Darch = "x86";
-          }
-        elseif($env:arch -eq "x64"){
+            $env:DConf = "m32";
+        }elseif($env:arch -eq "x64"){
             $env:compilersetupargs = "amd64";
             $env:Darch = "x86_64";
+            $env:DConf = "m64";
         }
-  - ps : if($env:DC -eq "dmd"){
-           $env:PATH += ";C:\dmd2\windows\bin;";
-         }
-         elseif($env:DC -eq "ldc"){
-           $version = $env:DVersion;
-           $env:PATH += ";C:\ldc2-$($version)-win64-msvc\bin";
-           $env:DC = "ldc2";
-         }
   - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";
   - '"%compilersetup%" %compilersetupargs%'
-
-build_script:
- - echo dummy build script - dont remove me
 
 test_script:
  - echo %PLATFORM%


### PR DESCRIPTION
Analog to https://github.com/etcimon/botan/pull/31.

It might be that the manually fixed versions fail due to a missing DUB binary. I guess the easiest way to prevent this is to always download DUB, e.g. as currently:

```yml
  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.2.1-windows-x86.zip -OutFile dub.zip
  - 7z x dub.zip -odub > nul
  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
  - dub --version
```