### PR TITLE
[waiting for CI to finish] AppVeyor: Always download DUB to avoid issues with missing bundles and remove LDC 32-bit builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,13 +33,7 @@ environment:
     arch: x86
   - DC: ldc
     DVersion: beta
-    arch: x86
-  - DC: ldc
-    DVersion: beta
     arch: x64
-  - DC: ldc
-    DVersion: stable
-    arch: x86
   - DC: ldc
     DVersion: stable
     arch: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,6 +113,11 @@ install:
             }
         }
   - ps: SetUpDCompiler
+  # some of the old releases aren't bundled with DUB, so for now we simply always download the newest DUB
+  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.2.1-windows-x86.zip -OutFile dub.zip
+  - 7z x dub.zip -odub > nul
+  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
+  - dub --version
 
 build_script:
   - ps: if($env:arch -eq "x86"){


### PR DESCRIPTION
Short follow-up to https://github.com/etcimon/libasync/pull/78

Most of the failures are due to a non-existent DUB binary in old releases, which this addition should fix - it takes about 10s to download and extract DUB, so the overhead is neglectable and this is also the way the `appveyor.yml` used to work.

However, there also seem to be weird linking errors with ldc in 32-bit mode:

```
libasync 0.8.3+commit.4.g44f4663: building configuration "libasync-test-regular"...
Enhanced memory security is enabled.
Memory debugger enabled
Using Windows message-based notifications and alertable IO for events
ws2_32_ex.lib : fatal error LNK1136: invalid or corrupt file
Error: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\link.exe failed with status: 1136
ldc2 failed with exit code 1136.
```

E.g.
https://ci.appveyor.com/project/etcimon/libasync/build/0.7.9.32/job/7lnfrmb5yirmlld7

Hence, for now at least I removed the 32-bit LDC builds.