### PR TITLE
[Do not merge] Improve appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Some or all of these limitations are possibly being implemented currently and ma
 Installation Instructions
 -------------------------
 
-- Download and install DMD 2.071.2+ from [dlang.org](http://dlang.org/download.html)
+- Download and install DMD 2.070.2+ from [dlang.org](http://dlang.org/download.html)
 - Download and install dub 1.0.0+ from [code.dlang.org](http://code.dlang.org/download)
 - Use Git to clone this repository
 - Run `dub test` to test the library on your operating system (submit any issue with a log report by uncommenting `enum LOG = true` in `types.d`)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Some or all of these limitations are possibly being implemented currently and ma
 Installation Instructions
 -------------------------
 
-- Download and install DMD 2.067.0+ from [dlang.org](http://dlang.org/download.html)
-- Download and install dub 0.9.22+ from [code.dlang.org](http://code.dlang.org/download)
+- Download and install DMD 2.071.2+ from [dlang.org](http://dlang.org/download.html)
+- Download and install dub 1.0.0+ from [code.dlang.org](http://code.dlang.org/download)
 - Use Git to clone this repository
 - Run `dub test` to test the library on your operating system (submit any issue with a log report by uncommenting `enum LOG = true` in `types.d`)
 - Add the library to your project by including it in the dependencies, using `import libasync`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,12 @@ environment:
   - DC: dmd
     DVersion: 2.071.2
     arch: x86
+  - DC: dmd
+    DVersion: 2.070.2
+    arch: x64
+  - DC: dmd
+    DVersion: 2.070.2
+    arch: x86
   - DC: ldc
     DVersion: beta
     arch: x64
@@ -38,7 +44,7 @@ environment:
     DVersion: stable
     arch: x64
   - DC: ldc
-    DVersion: 0.17.2
+    DVersion: 1.2.0
     arch: x64
 
 skip_tags: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,16 +20,16 @@ environment:
     DVersion: stable
     arch: x86
   - DC: dmd
-    DVersion: 2.067.2
+    DVersion: 2.073.2
     arch: x64
   - DC: dmd
-    DVersion: 2.067.2
+    DVersion: 2.073.2
     arch: x86
   - DC: dmd
-    DVersion: 2.068.2
+    DVersion: 2.071.2
     arch: x64
   - DC: dmd
-    DVersion: 2.068.2
+    DVersion: 2.071.2
     arch: x86
   - DC: ldc
     DVersion: beta
@@ -38,7 +38,7 @@ environment:
     DVersion: stable
     arch: x64
   - DC: ldc
-    DVersion: 0.17.3
+    DVersion: 0.17.2
     arch: x64
 
 skip_tags: false


### PR DESCRIPTION
> These versions are pretty old I'd probably just remove support for <2.069

I added a couple of dmd versions to find the lowest working one on Windows.
However, it seems that the failure with ldc-beta is a real one:

```
core.exception.AssertError@source\libasync\test.d(214): Assertion failure
----------------
0x00007FF7FA595CF9 in d_assert
0x00007FF7FA4ED929 in libasync.test.testMultiTimer.__lambda1 at C:\projects\libasync\source\libasync\test.d(214)
0x00007FF7FA4E2A0D in libasync.timer.TimerHandler.opCall at C:\projects\libasync\source\libasync\timer.d(150)
0x00007FF7FA4E03E6 in libasync.windows.EventLoopImpl.onMessage at C:\projects\libasync\source\libasync\windows.d(1825)
0x00007FF7FA4D1C77 in libasync.windows.wndProc at C:\projects\libasync\source\libasync\windows.d(2765)
0x00007FF961E724FD in DispatchMessageW
0x00007FF961E72357 in NotifyWinEvent
0x00007FF7FA4D2890 in libasync.windows.EventLoopImpl.loop at C:\projects\libasync\source\libasync\windows.d(302)
0x00007FF7FA4EA34E in libasync.events.EventLoop.loop at C:\projects\libasync\source\libasync\events.d(302)
0x00007FF7FA4E9E26 in libasync.test.__unittestL13_16 at C:\projects\libasync\source\libasync\test.d(38)
0x00007FF7FA5A321A in int core.runtime.runModuleUnitTests().__foreachbody1(object.ModuleInfo*)
0x00007FF7FA5A670F in int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))).__foreachbody2(ref rt.sections_ldc.SectionGroup)
0x00007FF7FA5A66BC in int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*)))
0x00007FF7FA5944DC in int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*))
0x00007FF7FA5A31E0 in runModuleUnitTests
0x00007FF7FA5A24AF in d_run_main
0x00007FF7FA5687C5 in __entrypoint.main at C:\projects\libasync\__entrypoint.d(8)
0x00007FF7FA5B3DA9 in __scrt_common_main_seh at f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl(253)
0x00007FF9626813D2 in BaseThreadInitThunk
0x00007FF9629F54E4 in RtlUserThreadStart
Program exited with code 1
```

https://ci.appveyor.com/project/etcimon/libasync/build/job/t4b3mxcpvuq1mfa6

Follow-up to https://github.com/etcimon/libasync/pull/79