### PR TITLE
Fix visibility attributes

### DIFF
--- a/source/libasync/types.d
+++ b/source/libasync/types.d
@@ -4,7 +4,7 @@ enum LOG = false; //trace
 enum DEBUG = false;
 
 import std.typecons: Flag;
-alias isIPv6 = Flag!"IPv6";
+public alias isIPv6 = Flag!"IPv6";
 alias isTCP = Flag!"TCP";
 alias isForced = Flag!"ForceFind";
 
@@ -56,7 +56,7 @@ struct StatusInfo {
 	string text;
 }
 
-enum Status : char {
+public enum Status : char {
 	OK					=	0,
 	ASYNC				=	1,
 	RETRY				=	2,


### PR DESCRIPTION
Currently this is blocking [1]. Please take a look at the changelog entry in [1]. Vibe-d is failing because of this. A few explanations: the declaration `enum Status` has the attribute `package` (on top of the module; I suggest you leave one empty line before and after the declaration because it is extremely easy to overlook it), which means that it is accessible only inside the libasync package; however, vibe.d uses `Status` and `isIpv6` also, so I made them public. I realize this may not be the best solution as those were not intended for external use, but I am not sufficiently familiar with your code to make a more elegant fix. After this issue is fixed (my merging this PR or any other way) please push a new tag so that vibe-d will appropriately use the latest version of libasync.

[1] https://github.com/dlang/dmd/pull/9393