### PR TITLE
Update logging.d

### DIFF
--- a/source/libasync/internals/logging.d
+++ b/source/libasync/internals/logging.d
@@ -1,11 +1,12 @@
 module libasync.internals.logging;
 
-import std.stdio : stdout;
 import libasync.types;
 static if (__VERSION__ < 2103){
+    import std.stdio : stdout;
     import std.experimental.logger;
 }
 else {
+    import std.stdio : stdout;
     import std.logger;
 }
 static __gshared FileLogger sharedLog;


### PR DESCRIPTION
Fix to make it building in Docker Linux - https://github.com/etcimon/libasync/issues/98

I can't understand the reason yet, but this simple change helped me to build a library in Docker